### PR TITLE
Update auto-categorizer page

### DIFF
--- a/accounting_package/platform_gl/configuration/categorization_config.mdx
+++ b/accounting_package/platform_gl/configuration/categorization_config.mdx
@@ -12,8 +12,6 @@ Teal uses a customizable pipeline to automate categorization, aiming to reduce t
 
 Sometimes our pipeline does not have enough information to categorize a transaction. In these cases, the transaction will be categorized into either the **Uncategorized Cash Inflow** or **Uncategorized Cash Outflow** ledger. 
 
-All auto-categorization steps are disabled by default, and will not run until manually enabled in the [developer portal](https://developer.teal.dev).
-
 ---
 
 ## Auto-categorization pipeline


### PR DESCRIPTION
Modify a line that erroneously states that all auto-categorizer steps are disabled by default. Only the AI categorizer is disabled by default. It now just generically states that your categorizers can be configured in the developer portal